### PR TITLE
correctly define react peer-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
   },
   "peerDependencies": {
     "@folio/stripes": "^9.0.0",
-    "react": "18.2.0",
+    "react": "^18.2.0",
     "react-intl": "^6.4.4",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",


### PR DESCRIPTION
Use a semver range instead of an exact version for react in the `peerDependencies` section.

